### PR TITLE
Add "span" to COPC header, fix reserved size

### DIFF
--- a/DRAFT-SPEC.md
+++ b/DRAFT-SPEC.md
@@ -35,10 +35,10 @@ The COPC VLR data is 80 bytes described by the following data structure.
 
     struct CopcData
     {
+      int64_t span;                 // Number of voxels in each spatial dimension
       uint64_t root_hier_offset;    // File offset to the first hierarchy page
       uint64_t root_hier_size;      // Size of the first hierarchy page in bytes.
-      uint16_t span;                // Number of voxels in each spatial dimension
-      uint64_t reserved[8];        // Reserved for future use.
+      uint64_t reserved[7];         // Reserved for future use.
     };
 
 ### WKT/spatial reference ("LASF_Projection"/2112)

--- a/DRAFT-SPEC.md
+++ b/DRAFT-SPEC.md
@@ -67,10 +67,11 @@ The VoxelKey corresponds to the naming of
 
     struct VoxelKey
     {
-      uint32_t level;
-      uint32_t x;
-      uint32_t y;
-      uint32_t z;
+      // A value < 0 indicates an invalid VoxelKey
+      int32_t level;
+      int32_t x;
+      int32_t y;
+      int32_t z;
     };
 
 An entry corresponds to a single key/value pair in an
@@ -101,7 +102,7 @@ in the page.
 
     struct Page
     {
-        uint64_t count;
+        int64_t count;
         Entry entires[count]; 
     };  // The total size of the hierarchy page is (32 * count) + 8 bytes
 

--- a/DRAFT-SPEC.md
+++ b/DRAFT-SPEC.md
@@ -38,7 +38,7 @@ The COPC VLR data is 80 bytes described by the following data structure.
       uint64_t root_hier_offset;    // File offset to the first hierarchy page
       uint64_t root_hier_size;      // Size of the first hierarchy page in bytes.
       uint16_t span;                // Number of voxels in each spatial dimension
-      uint64_t reserved[62];        // Reserved for future use.
+      uint64_t reserved[8];        // Reserved for future use.
     };
 
 ### WKT/spatial reference ("LASF_Projection"/2112)

--- a/DRAFT-SPEC.md
+++ b/DRAFT-SPEC.md
@@ -37,7 +37,8 @@ The COPC VLR data is 80 bytes described by the following data structure.
     {
       uint64_t root_hier_offset;    // File offset to the first hierarchy page
       uint64_t root_hier_size;      // Size of the first hierarchy page in bytes.
-      uint64_t reserved[8];         // Reserved for future use.
+      uint16_t span;                // Number of voxels in each spatial dimension
+      uint64_t reserved[62];        // Reserved for future use.
     };
 
 ### WKT/spatial reference ("LASF_Projection"/2112)

--- a/DRAFT-SPEC.md
+++ b/DRAFT-SPEC.md
@@ -67,10 +67,10 @@ The VoxelKey corresponds to the naming of
 
     struct VoxelKey
     {
-      int32_t level;
-      int32_t x;
-      int32_t y;
-      int32_t z;
+      uint32_t level;
+      uint32_t x;
+      uint32_t y;
+      uint32_t z;
     };
 
 An entry corresponds to a single key/value pair in an


### PR DESCRIPTION
Add the [span](https://entwine.io/entwine-point-tile.html#span) attribute to the CopcData struct, which is necessary to store. 

Fixed the size of the `reserved` array to make the struct take up 80 bytes (we can add additional elements and make the size smaller as needed). Or, if you want, we can create a separate padding element to come before `reserved` that fills in that space.