### PR TITLE
Apply requirements for reserved bytes to writers only

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The ``info`` VLR *MUST* be the **first** VLR in the file (must begin at offset 3
 the beginning of the file).
 
 The ``info`` VLR is ``160`` bytes described by the following structure.
-``reserved`` elements *MUST* be set to ``0``.
+Writers *MUST* set ``reserved`` elements to ``0``.
 
     struct CopcInfo
     {
@@ -102,7 +102,7 @@ The ``info`` VLR is ``160`` bytes described by the following structure.
       // Size of the first hierarchy page in bytes
       uint64_t root_hier_size;
 
-      // Reserved for future use. Must be 0.
+      // Reserved for future use. Writers must set these to 0.
       uint64_t reserved[13];
     };
 


### PR DESCRIPTION
Minor nit - if the "reserved" values are indeed reserved for future use, I suppose requirements on their value should only apply to writers. Otherwise, we might get forward incompatibility in validating readers that take the spec literally.