### PR TITLE
Remove "Reserved for future use" wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The ``info`` VLR is ``160`` bytes described by the following structure.
       // Size of the first hierarchy page in bytes
       uint64_t root_hier_size;
 
-      // Reserved for future use. Must be 0.
+      // Must be 0
       uint64_t reserved[13];
     };
 


### PR DESCRIPTION
I gather from the discussion in #42 that it is not intended to ever allow anything but zeros in the "reserved" fields (at least without a breaking change). Thus, the wording "Reserved for future use" is removed.

Closes #42 