### PR TITLE
Add Giro3D to COPC software implementations

### DIFF
--- a/software.md
+++ b/software.md
@@ -4,6 +4,7 @@
 * [PDAL readers.copc](http://pdal.io/stages/readers.copc.html)
 * [PDAL writers.copc](http://pdal.io/stages/writers.copc.html)
 * [copc.js](https://github.com/connormanning/copc.js)
+* [Giro3D](https://giro3d.org) - thanks to copc.js
 * [COPC-lib](https://github.com/RockRobotic/copc-lib/)
 * [Manifold Release 9](https://manifold.net/)
 * [laspy](https://github.com/laspy/laspy/pull/219)


### PR DESCRIPTION
also mention that support is provided thanks to copc.js

The current support is not merged yet, but it should be ready and merged soon, we can anticipate a bit : https://gitlab.com/giro3d/giro3d/-/merge_requests/750