### PR TITLE
feat: add itowns to the list of COPC readers

### DIFF
--- a/software.md
+++ b/software.md
@@ -4,6 +4,7 @@
 * [PDAL readers.copc](http://pdal.io/stages/readers.copc.html)
 * [PDAL writers.copc](http://pdal.io/stages/writers.copc.html)
 * [copc.js](https://github.com/connormanning/copc.js)
+* [iTowns](https://github.com/iTowns/itowns) - powered by copc.js (cheers!)
 * [Giro3D](https://giro3d.org) - thanks to copc.js
 * [COPC-lib](https://github.com/RockRobotic/copc-lib/)
 * [Manifold Release 9](https://manifold.net/)


### PR DESCRIPTION
Hi!

We have full support for reading COPC datasets built on top of `copc.js` (thanks again @connormanning) since a year in [`iTowns`](https://github.com/itowns/itowns).

Would it be possible to add `itowns` to the list of COPC-compatible readers?